### PR TITLE
Task/eparker71/tlt 2259 add new shopping banner

### DIFF
--- a/js/shop.js
+++ b/js/shop.js
@@ -12,122 +12,117 @@ var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8'
  * with additional checks to show shopping messages if authorized
  * @type {boolean}
  */
-var is_authorized = $('#unauthorized_message').length > 0 ? false : true;
+var authorized = $('#unauthorized_message').length > 0 ? false : true;
+if (authorized){
+  var un = $('ul#identity > li.user_name > a').text();
+  if ( !un ) {
+    $.getJSON(course_url, function( data ) {
+      /*
+       Check to see the course is in the 'available' (Published) state before showing
+       the shopping button.
+       */
 
-/**
- * Check if the term is allowed
- * @param term_id
- * @returns {boolean}
- */
-function term_allowed(term_id) {
-  return jQuery.inArray(term_id, allowed_terms) > -1;
-}
-
-/**
- * Check to see if the course is available
- * @param course_workflow
- * @returns {boolean}
- */
-function is_course_available(course_workflow) {
-  return course_workflow.localeCompare('available') == 0;
-}
-
-if(is_course && !on_special_page) {
-  if (is_authorized){
-    var usernname = $('ul#identity > li.user_name > a').text();
-    if ( !usernname ) {
-      $.getJSON(course_url, function( data ) {
-          /*
-           TLT-668 - only allow shopping for terms that are in the whitelist.
-           */
-          if (is_course_available(data['workflow_state']) && term_allowed(data['enrollment_term_id'])) {
-            shopping_banner.append(no_user_canvas_login);
-            $('#breadcrumbs').after(shopping_banner);
-          }
-      });
-    }
-    else {
-      var sis_user_id = '';
-      $.getJSON(user_url, function( data ) {
-        sis_user_id = get_sis_user_id(data);
+      if(is_course_available(data['workflow_state']) && !on_special_page) {
+        /*
+         TLT-668 - only allow shopping for terms that are in the whitelist.
+         */
+        if (term_allowed(data['enrollment_term_id'])) {
+          shopping_banner.append(no_user_canvas_login);
+          $('#breadcrumbs').after(shopping_banner);
+        }
+      }
+    });
+  }
+  else {
+    var sis_user_id = '';
+    $.getJSON(user_url, function( data ) {
+      sis_user_id = get_sis_user_id(data);
+      if (course_id > 0) {
         $.getJSON(course_url, function( data ) {
           /*
-           TLT-668 - only allow shopping for terms that are in the whitelist.
+           Check to see the course is in the 'available' (Published) state before showing
+           the shopping button.
            */
-          if (is_course_available(data['workflow_state']) && term_allowed(data['enrollment_term_id'])) {
-            var c_id = data['id'];
-            if (course_id == c_id) {
-              var num_enrollments = data['enrollments'].length;
-              for (var n = 0; n < num_enrollments; n++) {
-                var erole = data['enrollments'][n]['role'];
-                var type =  data['enrollments'][n]['type'];
-                user_enrolled = true;
-                is_shopper = (erole == 'Shopper');
-                is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');
-                is_teacher =  (type == 'teacher' || type == 'ta' ||type == 'designer' );
-              }
-            }
-
-            var login_id = '?canvas_login_id=' + sis_user_id;
-            var course_and_user_id_param = course_id + login_id;
-
-            var add_shopper_url = shopping_tool_url + '/shop_course/' + course_and_user_id_param;
-            var remove_shopper_url = shopping_tool_url + '/remove_shopper_role/' + course_and_user_id_param;
-            var manage_shopping_page_url = shopping_tool_url + '/my_list' + login_id;
-
-            var manage_shopping_li_item = jQuery('<li/>', {
-              id: 'manage-shopping',
-              class: 'menu-item'
-            });
-
-            var manage_shopping_link = jQuery('<a/>', {
-              id: 'manage-shopping-page-link',
-              class: 'menu-item-no-drop',
-              href: manage_shopping_page_url,
-              text: "Courses I'm Shopping"
-            });
-
+          if(is_course_available(data['workflow_state']) && !on_special_page) {
             /*
-             build the Manage Shopping menu item
+             TLT-668 - only allow shopping for terms that are in the whitelist.
              */
-            if (user_enrolled) {
-              manage_shopping_li_item.append(manage_shopping_link);
+            if (term_allowed(data['enrollment_term_id'])) {
+              var c_id = data['id'];
+              if (course_id == c_id) {
+                var num_enrollments = data['enrollments'].length;
+                for (var n = 0; n < num_enrollments; n++) {
+                  var erole = data['enrollments'][n]['role'];
+                  var type =  data['enrollments'][n]['type'];
+                  user_enrolled = true;
+                  is_shopper = (erole == 'Shopper');
+                  is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');
+                  is_teacher =  (type == 'teacher' || type == 'ta' ||type == 'designer' );
+                }
+              }
+
+              var login_id = '?canvas_login_id=' + sis_user_id;
+              var course_and_user_id_param = course_id + login_id;
+
+              var add_shopper_url = shopping_tool_url + '/shop_course/' + course_and_user_id_param;
+              var remove_shopper_url = shopping_tool_url + '/remove_shopper_role/' + course_and_user_id_param;
+              var manage_shopping_page_url = shopping_tool_url + '/my_list' + login_id;
+
+              var manage_shopping_li_item = jQuery('<li/>', {
+                id: 'manage-shopping',
+                class: 'menu-item'
+              });
+
+              var manage_shopping_link = jQuery('<a/>', {
+                id: 'manage-shopping-page-link',
+                class: 'menu-item-no-drop',
+                href: manage_shopping_page_url,
+                text: "Courses I'm Shopping"
+              });
+
               /*
-               for each role format the appropriate banner
+               build the Manage Shopping menu item
                */
-              if (is_shopper) {
+              if (user_enrolled) {
+                manage_shopping_li_item.append(manage_shopping_link);
+
+                /*
+                 for each role format the appropriate banner
+                 */
+                if (is_shopper) {
+                  $("ul#menu").append(manage_shopping_li_item);
+                  shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
+                }
+                else if (is_teacher) {
+                  shopping_banner.append(shopping_get_is_active_banner_text());
+                }
+                else if(is_student){
+                  shopping_banner.append(shopping_get_student_banner_text());
+                }
+                /*
+                 display the banner formatted above
+                 */
+                if (is_shopper || is_teacher || is_student) {
+                  $('#breadcrumbs').after(shopping_banner);
+                }
+              }else{
+                /*
+                 If logged in user is not enrolled, then display generic shopping message to authorized user
+                 */
                 $("ul#menu").append(manage_shopping_li_item);
-                shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
-              }
-              else if (is_teacher) {
-                shopping_banner.append(shopping_get_is_active_banner_text());
-              }
-              else if(is_student){
-                shopping_banner.append(shopping_get_student_banner_text());
-              }
-              /*
-               display the banner formatted above
-               */
-              if (is_shopper || is_teacher || is_student) {
+                shopping_banner.append(shopping_get_viewer_banner_text(add_shopper_url));
                 $('#breadcrumbs').after(shopping_banner);
               }
-            } else {
-              /*
-               If logged in user is not enrolled, then display generic shopping message to authorized user
-               */
-              $("ul#menu").append(manage_shopping_li_item);
-              shopping_banner.append(shopping_get_viewer_banner_text(add_shopper_url));
-              $('#breadcrumbs').after(shopping_banner);
             }
+          } else if (on_admin_page && term_allowed(data['enrollment_term_id'])) {
+            // on course admin page for course in a whitelisted term --> disable is_public_to_auth_users
+            var $iptau_checkbox = $('#course_is_public_to_auth_users');
+            $iptau_checkbox.closest("div").addClass("selection-disabled");
+            $iptau_checkbox.closest("span").after('<span> <em>(this cannot be changed during shopping period)</em></span>');
+            $iptau_checkbox.attr("disabled", true);
           }
         });
-      });
-    }
+      }
+    });
   }
-} else if (on_admin_page && term_allowed(data['enrollment_term_id'])) {
-  // on course admin page for course in a whitelisted term --> disable is_public_to_auth_users
-  var $iptau_checkbox = $('#course_is_public_to_auth_users');
-  $iptau_checkbox.closest("div").addClass("selection-disabled");
-  $iptau_checkbox.closest("span").after('<span> <em>(this cannot be changed during shopping period)</em></span>');
-  $iptau_checkbox.attr("disabled", true);
 }

--- a/js/shop.js
+++ b/js/shop.js
@@ -7,6 +7,15 @@
  */
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
+/**
+ * Check if the term id is in the allowed terms list
+ * @param term_id
+ * @returns {boolean}
+ */
+function term_allowed(term_id) {
+  return jQuery.inArray(term_id, allowed_terms) > -1;
+}
+
 var current_user_id = ENV['current_user_id'];
 var user_url = '/api/v1/users/' + current_user_id + '/profile';
 var course_id = get_course_number();

--- a/js/shop.js
+++ b/js/shop.js
@@ -7,80 +7,7 @@
  */
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
-/**
- * Check if the term id is in the allowed terms list
- * @param term_id
- * @returns {boolean}
- */
-function term_allowed(term_id) {
-  return jQuery.inArray(term_id, allowed_terms) > -1;
-}
-
-var current_user_id = ENV['current_user_id'];
-var user_url = '/api/v1/users/' + current_user_id + '/profile';
-var course_id = get_course_number();
-var course_url = '/api/v1/courses/' + course_id ;
-var login_url = window.location.origin+"/login";
-var shopping_tool_url = "https://icommons-tools.dev.tlt.harvard.edu/shopping";
-
-/**
- * Tool tip text and html link
- * @type {string}
- */
-var shopping_help_doc_url = 'https://wiki.harvard.edu/confluence/display/canvas/Course+Shopping';
-var data_tooltip = 'More info about access during shopping period';
-var tooltip_link = '<a data-tooltip title="' + data_tooltip + '" target="_blank" href="' +
-  shopping_help_doc_url + '"><i class="icon-question"></i></a>';
-
-var no_user_canvas_login = '<div class="tltmsg tltmsg-shop"><p class="participate-text">Students: ' +
-  '<a href="'+login_url+'">login</a> to get more access during shopping period.' + tooltip_link + '</p></div>';
-
-var is_course = (course_id > 0);
-var user_enrolled = false;
-var is_shopper = false;
-var is_teacher = false;
-var is_student = false;
-
-/**
- * Create the div that will hold the shoping banner
- * @type {html element}
- */
-var shopping_banner = jQuery('<div/>', {
-  id: 'course-shopping',
-  class: 'tltmsg'
-});
-
-/**
- * Are we on an admin page
- * @type {boolean}
- */
-var on_admin_page = ((window.location.pathname).indexOf('settings') != -1);
-
-/**
- * Are we on the speed grader page
- * @type {boolean}
- */
-var on_speed_grader_page = ((window.location.pathname).indexOf('speed_grader') != -1);
-
-/**
- * Are we on the submissions page
- * @type {boolean}
- */
-var on_submissions_page = ((window.location.pathname).indexOf('submissions') != -1);
-
-/**
- * Are we on any of the special pages described above
- * @type {boolean}
- */
-var on_special_page = on_admin_page || on_speed_grader_page || on_submissions_page;
-
-/**
- * check to see if the '#unauthorized_message' is being rendered  and only proceed
- * with additional checks to show shopping messages if authorized
- * @type {boolean}
- */
-var authorized = $('#unauthorized_message').length > 0 ? false : true;
-if (authorized){
+if (is_unauthorized_message_shown){
   var un = $('ul#identity > li.user_name > a').text();
   if ( !un ) {
     $.getJSON(course_url, function( data ) {
@@ -88,12 +15,11 @@ if (authorized){
        Check to see the course is in the 'available' (Published) state before showing
        the shopping button.
        */
-
       if(is_course_available(data['workflow_state']) && !on_special_page) {
         /*
          TLT-668 - only allow shopping for terms that are in the whitelist.
          */
-        if (term_allowed(data['enrollment_term_id'])) {
+        if (is_term_allowed(data['enrollment_term_id'])) {
           shopping_banner.append(no_user_canvas_login);
           $('#breadcrumbs').after(shopping_banner);
         }
@@ -114,7 +40,7 @@ if (authorized){
             /*
              TLT-668 - only allow shopping for terms that are in the whitelist.
              */
-            if (term_allowed(data['enrollment_term_id'])) {
+            if (is_term_allowed(data['enrollment_term_id'])) {
               var c_id = data['id'];
               if (course_id == c_id) {
                 var num_enrollments = data['enrollments'].length;
@@ -181,7 +107,7 @@ if (authorized){
                 $('#breadcrumbs').after(shopping_banner);
               }
             }
-          } else if (on_admin_page && term_allowed(data['enrollment_term_id'])) {
+          } else if (on_admin_page && is_term_allowed(data['enrollment_term_id'])) {
             // on course admin page for course in a whitelisted term --> disable is_public_to_auth_users
             var $iptau_checkbox = $('#course_is_public_to_auth_users');
             $iptau_checkbox.closest("div").addClass("selection-disabled");

--- a/js/shop.js
+++ b/js/shop.js
@@ -8,39 +8,7 @@ var shopping_tool_url = "https://icommons-tools.dev.tlt.harvard.edu/shopping";  
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 // var shopping_tool_url = "https://icommons-tools.stage.tlt.harvard.edu/shopping";    // the url of the shopping tool
 
-/*
- get the course number for the canvas course
- */
-function get_course_number() {
-  var page_url = window.location.pathname;
-  var pat = /\/courses\/(\d+)/g;
-  var match = pat.exec(page_url);
-  if (match) {
-    course_id = match[1];
-    return course_id;
-  }
-  return 0;
-}
 
-function get_sis_user_id(canvas_user_api_data) {
-  var user_id = null;
-  if (canvas_user_api_data) {
-    if (canvas_user_api_data['sis_user_id'] && canvas_user_api_data['sis_user_id'].trim()) {
-      user_id = canvas_user_api_data['sis_user_id'].trim();
-    } else if (canvas_user_api_data['login_id'] && canvas_user_api_data['login_id'].trim()) {
-      user_id = canvas_user_api_data['login_id'].trim();
-    }
-  }
-  return user_id;
-}
-
-function is_course_available(course_workflow) {
-  return course_workflow.localeCompare('available') == 0;
-}
-
-function term_allowed(term_id) {
-  return jQuery.inArray(term_id, allowed_terms) > -1;
-}
 
 var current_user_id = ENV['current_user_id'];							// the canvas id if the current user
 var user_url = '/api/v1/users/' + current_user_id + '/profile';			// the url to the user profile api call
@@ -54,10 +22,7 @@ var tooltip_link = '<a data-tooltip title="' + data_tooltip + '" target="_blank"
 var login_url = window.location.origin+"/login";
 var no_user_canvas_login = "<div class='tltmsg tltmsg-shop'><p class='participate-text'>Students: <a href=\""+login_url+"\">login</a> to get more access during shopping period." + tooltip_link + "</p></div>";
 
-var on_admin_page = ((window.location.pathname).indexOf('settings') != -1);
-var on_speed_grader_page = ((window.location.pathname).indexOf('speed_grader') != -1);
-var on_submissions_page = ((window.location.pathname).indexOf('submissions') != -1);
-var on_special_page = on_admin_page || on_speed_grader_page || on_submissions_page;
+
 
 var user_enrolled = false;
 var is_shopper = false;
@@ -162,32 +127,32 @@ if (authorized){
                text messages
                */
 
-              var student_message_text = '<h1>All Harvard ID holders can view this course site during shopping ' +
-                  'period. ' + tooltip_link + '</h1><p>Your contributions will be visible to other students who ' +
-                  'are also shopping this course.</p>';
-
-              var shopper_message_text = '<div class="shop-msg-left"><h1>This course has been added to your shopping ' +
-                  'list ' + tooltip_link + '</h1><p>This means that you can receive notifications, join discussions, ' +
-                  'watch lecture videos, and upload assignments during shopping period. Your contributions will be ' +
-                  'visible to other students who are also shopping this course. You will be removed from this course ' +
-                  'at the end of shopping period unless you officially enroll through the Registrar’s office.' +
-                  '</p></div><div class="shop-btn-right">' +
-                  '<a class="btn btn-small btn-primary" href="' +remove_shopper_url+ '">Remove Course</a></div>';
-
-              var viewer_message_text = '<div class="shop-msg-left"><h1>Students: do you want to add this course to ' +
-                  'your shopping list?' + tooltip_link +'</h1><p>Click the Add Course button to receive ' +
-                  'notifications, join discussions, watch lecture videos, and upload assignments. You must enroll ' +
-                  'through the Registrar’s office to be officially enrolled as a Student in this course.' +
-                  '</p></div><div class="shop-btn-right">' +
-                  '<a class="btn btn-small btn-primary" href="' + add_shopper_url + '">Add Course</a></div>';
-
-              var shopping_is_active_message = '<h1>Your current class list may include Shoppers. ' + tooltip_link +
-                  '</h1><p>All Harvard ID holders can view this course site during shopping period. Students ' +
-                  'can choose to add themselves as Shoppers to participate in discussions, upload assignments, watch ' +
-                  'lecture videos, and receive notifications for this course before they are officially enrolled. '+
-                  'Student contributions will be visible to other students who are also shopping this course. At the '+
-                  'end of shopping period, Shoppers who have not officially enrolled as Students or Guests in the '+
-                  'course through the Registrar’s office will be removed from the class list.</p>';
+              //var student_message_text = '<h1>All Harvard ID holders can view this course site during shopping ' +
+              //    'period. ' + tooltip_link + '</h1><p>Your contributions will be visible to other students who ' +
+              //    'are also shopping this course.</p>';
+              //
+              //var shopper_message_text = '<div class="shop-msg-left"><h1>This course has been added to your shopping ' +
+              //    'list ' + tooltip_link + '</h1><p>This means that you can receive notifications, join discussions, ' +
+              //    'watch lecture videos, and upload assignments during shopping period. Your contributions will be ' +
+              //    'visible to other students who are also shopping this course. You will be removed from this course ' +
+              //    'at the end of shopping period unless you officially enroll through the Registrar’s office.' +
+              //    '</p></div><div class="shop-btn-right">' +
+              //    '<a class="btn btn-small btn-primary" href="' +remove_shopper_url+ '">Remove Course</a></div>';
+              //
+              //var viewer_message_text = '<div class="shop-msg-left"><h1>Students: do you want to add this course to ' +
+              //    'your shopping list?' + tooltip_link +'</h1><p>Click the Add Course button to receive ' +
+              //    'notifications, join discussions, watch lecture videos, and upload assignments. You must enroll ' +
+              //    'through the Registrar’s office to be officially enrolled as a Student in this course.' +
+              //    '</p></div><div class="shop-btn-right">' +
+              //    '<a class="btn btn-small btn-primary" href="' + add_shopper_url + '">Add Course</a></div>';
+              //
+              //var shopping_is_active_message = '<h1>Your current class list may include Shoppers. ' + tooltip_link +
+              //    '</h1><p>All Harvard ID holders can view this course site during shopping period. Students ' +
+              //    'can choose to add themselves as Shoppers to participate in discussions, upload assignments, watch ' +
+              //    'lecture videos, and receive notifications for this course before they are officially enrolled. '+
+              //    'Student contributions will be visible to other students who are also shopping this course. At the '+
+              //    'end of shopping period, Shoppers who have not officially enrolled as Students or Guests in the '+
+              //    'course through the Registrar’s office will be removed from the class list.</p>';
 
               var manage_shopping_li_item = jQuery('<li/>', {
                 id: 'manage-shopping',
@@ -212,13 +177,13 @@ if (authorized){
                  */
                 if (is_shopper) {
                   $("ul#menu").append(manage_shopping_li_item);
-                  shopping_banner.append(shopper_message_text);
+                  shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
                 }
                 else if (is_teacher) {
-                  shopping_banner.append(shopping_is_active_message);
+                  shopping_banner.append(shopping_get_is_active_banner_text());
                 }
                 else if(is_student){
-                  shopping_banner.append(student_message_text);
+                  shopping_banner.append(shopping_get_student_banner_text());
                 }
                 /*
                  display the banner formatted above
@@ -231,7 +196,7 @@ if (authorized){
                  If logged in user is not enrolled, then display generic shopping message to authorized user
                  */
                 $("ul#menu").append(manage_shopping_li_item);
-                shopping_banner.append(viewer_message_text);
+                shopping_banner.append(shopping_get_viewer_banner_text(add_shopper_url));
                 $('#breadcrumbs').after(shopping_banner);
               }
             }

--- a/js/shop.js
+++ b/js/shop.js
@@ -15,14 +15,12 @@ if (is_unauthorized_message_shown){
        Check to see the course is in the 'available' (Published) state before showing
        the shopping button.
        */
-      if(is_course_available(data['workflow_state']) && !on_special_page) {
-        /*
-         TLT-668 - only allow shopping for terms that are in the whitelist.
-         */
-        if (is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
-          shopping_banner.append(no_user_canvas_login);
-          $('#breadcrumbs').after(shopping_banner);
-        }
+      var course_is_available = is_course_available(data['workflow_state']);
+      var term_is_allowed = is_term_allowed(data['enrollment_term_id'], allowed_terms);
+
+      if(course_is_available && !on_special_page && term_is_allowed) {
+        shopping_banner.append(no_user_canvas_login);
+        $('#breadcrumbs').after(shopping_banner);
       }
     });
   }
@@ -32,82 +30,70 @@ if (is_unauthorized_message_shown){
       sis_user_id = get_sis_user_id(data);
       if (course_id > 0) {
         $.getJSON(course_url, function( data ) {
+
+          var course_is_available = is_course_available(data['workflow_state']);
+          var term_is_allowed = is_term_allowed(data['enrollment_term_id'], allowed_terms);
+          var course_enrollments = data['enrollments'];
+          var c_id = data['id'];
+
           /*
            Check to see the course is in the 'available' (Published) state before showing
            the shopping button.
            */
-          if(is_course_available(data['workflow_state']) && !on_special_page) {
+          if(course_is_available && !on_special_page && term_is_allowed && course_id == c_id) {
+            var num_enrollments = course_enrollments.length;
+            for (var n = 0; n < num_enrollments; n++) {
+              var erole = course_enrollments[n]['role'];
+              var type =  course_enrollments['type'];
+              user_enrolled = true;
+              is_shopper = (erole == 'Shopper');
+              is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');
+              is_teacher =  (type == 'teacher' || type == 'ta' ||type == 'designer' );
+            }
+
+            var login_id = '?canvas_login_id=' + sis_user_id;
+            var course_and_user_id_param = course_id + login_id;
+            var add_shopper_url = shopping_tool_url + '/shop_course/' + course_and_user_id_param;
+            var remove_shopper_url = shopping_tool_url + '/remove_shopper_role/' + course_and_user_id_param;
+            var manage_shopping_page_url = shopping_tool_url + '/my_list' + login_id;
+            var manage_shopping_li_item = jQuery('<li/>', {
+              id: 'manage-shopping',
+              class: 'menu-item'
+            });
+            var manage_shopping_link = jQuery('<a/>', {
+              id: 'manage-shopping-page-link',
+              class: 'menu-item-no-drop',
+              href: manage_shopping_page_url,
+              text: "Courses I'm Shopping"
+            });
             /*
-             TLT-668 - only allow shopping for terms that are in the whitelist.
+             build the Manage Shopping menu item
              */
-            if (is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
-              var c_id = data['id'];
-              if (course_id == c_id) {
-                var num_enrollments = data['enrollments'].length;
-                for (var n = 0; n < num_enrollments; n++) {
-                  var erole = data['enrollments'][n]['role'];
-                  var type =  data['enrollments'][n]['type'];
-                  user_enrolled = true;
-                  is_shopper = (erole == 'Shopper');
-                  is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');
-                  is_teacher =  (type == 'teacher' || type == 'ta' ||type == 'designer' );
-                }
-              }
-
-              var login_id = '?canvas_login_id=' + sis_user_id;
-              var course_and_user_id_param = course_id + login_id;
-
-              var add_shopper_url = shopping_tool_url + '/shop_course/' + course_and_user_id_param;
-              var remove_shopper_url = shopping_tool_url + '/remove_shopper_role/' + course_and_user_id_param;
-              var manage_shopping_page_url = shopping_tool_url + '/my_list' + login_id;
-
-              var manage_shopping_li_item = jQuery('<li/>', {
-                id: 'manage-shopping',
-                class: 'menu-item'
-              });
-
-              var manage_shopping_link = jQuery('<a/>', {
-                id: 'manage-shopping-page-link',
-                class: 'menu-item-no-drop',
-                href: manage_shopping_page_url,
-                text: "Courses I'm Shopping"
-              });
-
-              /*
-               build the Manage Shopping menu item
-               */
-              if (user_enrolled) {
-                manage_shopping_li_item.append(manage_shopping_link);
-
-                /*
-                 for each role format the appropriate banner
-                 */
-                if (is_shopper) {
-                  $("ul#menu").append(manage_shopping_li_item);
-                  shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
-                }
-                else if (is_teacher) {
-                  shopping_banner.append(shopping_get_is_active_banner_text());
-                }
-                else if(is_student){
-                  shopping_banner.append(shopping_get_student_banner_text());
-                }
-                /*
-                 display the banner formatted above
-                 */
-                if (is_shopper || is_teacher || is_student) {
-                  $('#breadcrumbs').after(shopping_banner);
-                }
-              }else{
-                /*
-                 If logged in user is not enrolled, then display generic shopping message to authorized user
-                 */
+            if (user_enrolled) {
+              manage_shopping_li_item.append(manage_shopping_link);
+              if (is_shopper) {
                 $("ul#menu").append(manage_shopping_li_item);
-                shopping_banner.append(shopping_get_viewer_banner_text(add_shopper_url));
+                shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
+              }
+              else if (is_teacher) {
+                shopping_banner.append(shopping_get_is_active_banner_text());
+              }
+              else if(is_student){
+                shopping_banner.append(shopping_get_student_banner_text());
+              }
+              if (is_shopper || is_teacher || is_student) {
                 $('#breadcrumbs').after(shopping_banner);
               }
+            }else{
+              /*
+               If logged in user is not enrolled, then display generic shopping
+               message to authorized user
+               */
+              $("ul#menu").append(manage_shopping_li_item);
+              shopping_banner.append(shopping_get_viewer_banner_text(add_shopper_url));
+              $('#breadcrumbs').after(shopping_banner);
             }
-          } else if (on_admin_page && is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
+          } else if (on_admin_page && term_is_allowed) {
             // on course admin page for course in a whitelisted term --> disable is_public_to_auth_users
             var $iptau_checkbox = $('#course_is_public_to_auth_users');
             $iptau_checkbox.closest("div").addClass("selection-disabled");

--- a/js/shop.js
+++ b/js/shop.js
@@ -132,7 +132,7 @@ if (authorized){
                   user_enrolled = true;
 
                   is_shopper = (erole == 'Shopper');
-                  is_student = (erole == 'StudentEnrollment-Viewer');
+                  is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');
                   /* Base the teacher check on 'type' instead of 'role' to capture most teacher roles. Since Designer and
                   	TA have their own special type, they are checked separately. Student/Shopper
                    check would still use role as they are both of type 'student'
@@ -161,6 +161,10 @@ if (authorized){
               /*
                text messages
                */
+
+              var student_message_text = '<h1>All Harvard ID holders can view this course site during shopping ' +
+                  'period. ' + tooltip_link + '</h1><p>Your contributions will be visible to other students who ' +
+                  'are also shopping this course.</p>';
 
               var shopper_message_text = '<div class="shop-msg-left"><h1>This course has been added to your shopping ' +
                   'list ' + tooltip_link + '</h1><p>This means that you can receive notifications, join discussions, ' +
@@ -212,6 +216,9 @@ if (authorized){
                 }
                 else if (is_teacher) {
                   shopping_banner.append(shopping_is_active_message);
+                }
+                else if(is_student){
+                  shopping_banner.append(student_message_text);
                 }
                 /*
                  display the banner formatted above

--- a/js/shop.js
+++ b/js/shop.js
@@ -8,6 +8,13 @@
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
 /**
+ * check to see if the '#unauthorized_message' is being rendered  and only proceed
+ * with additional checks to show shopping messages if authorized
+ * @type {boolean}
+ */
+var is_authorized = $('#unauthorized_message').length > 0 ? false : true;
+
+/**
  * Check if the term is allowed
  * @param term_id
  * @returns {boolean}
@@ -16,7 +23,16 @@ function term_allowed(term_id) {
   return jQuery.inArray(term_id, allowed_terms) > -1;
 }
 
-if(is_course && is_course_available(data['workflow_state']) && !on_special_page) {
+/**
+ * Check to see if the course is available
+ * @param course_workflow
+ * @returns {boolean}
+ */
+function is_course_available(course_workflow) {
+  return course_workflow.localeCompare('available') == 0;
+}
+
+if(is_course && !on_special_page) {
   if (is_authorized){
     var usernname = $('ul#identity > li.user_name > a').text();
     if ( !usernname ) {
@@ -24,7 +40,7 @@ if(is_course && is_course_available(data['workflow_state']) && !on_special_page)
           /*
            TLT-668 - only allow shopping for terms that are in the whitelist.
            */
-          if (term_allowed(data['enrollment_term_id'])) {
+          if (is_course_available(data['workflow_state']) && term_allowed(data['enrollment_term_id'])) {
             shopping_banner.append(no_user_canvas_login);
             $('#breadcrumbs').after(shopping_banner);
           }
@@ -38,7 +54,7 @@ if(is_course && is_course_available(data['workflow_state']) && !on_special_page)
           /*
            TLT-668 - only allow shopping for terms that are in the whitelist.
            */
-          if (term_allowed(data['enrollment_term_id'])) {
+          if (is_course_available(data['workflow_state']) && term_allowed(data['enrollment_term_id'])) {
             var c_id = data['id'];
             if (course_id == c_id) {
               var num_enrollments = data['enrollments'].length;

--- a/js/shop.js
+++ b/js/shop.js
@@ -7,7 +7,20 @@
  */
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
-if (unauthorized_message_not_shown){
+var course_id_is_valid = (course_id > 0);
+var user_enrolled = false;
+var is_shopper = false;
+var is_teacher = false;
+var is_student = false;
+
+/**
+ * check to see if the '#unauthorized_message' is being rendered  and only proceed
+ * with additional checks to show shopping messages if authorized
+ * @type {boolean}
+ */
+var authorized = $('#unauthorized_message').length > 0 ? false : true;
+
+if (authorized){
   var un = $('ul#identity > li.user_name > a').text();
   if ( !un ) {
     $.getJSON(course_url, function( data ) {
@@ -76,7 +89,7 @@ if (unauthorized_message_not_shown){
                 shopping_banner.append(shopping_get_shopper_banner_text(remove_shopper_url));
               }
               else if (is_teacher) {
-                shopping_banner.append(shopping_get_is_active_banner_text());
+                shopping_banner.append(shopping_get_teacher_banner_text());
               }
               else if(is_student){
                 shopping_banner.append(shopping_get_student_banner_text());

--- a/js/shop.js
+++ b/js/shop.js
@@ -223,7 +223,7 @@ if (authorized){
                 /*
                  display the banner formatted above
                  */
-                if (is_shopper || is_teacher) {
+                if (is_shopper || is_teacher || is_student) {
                   $('#breadcrumbs').after(shopping_banner);
                 }
               }else{

--- a/js/shop.js
+++ b/js/shop.js
@@ -7,6 +7,64 @@
  */
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
+var current_user_id = ENV['current_user_id'];
+var user_url = '/api/v1/users/' + current_user_id + '/profile';
+var course_id = get_course_number();
+var course_url = '/api/v1/courses/' + course_id ;
+var login_url = window.location.origin+"/login";
+var shopping_tool_url = "https://icommons-tools.dev.tlt.harvard.edu/shopping";
+
+/**
+ * Tool tip text and html link
+ * @type {string}
+ */
+var shopping_help_doc_url = 'https://wiki.harvard.edu/confluence/display/canvas/Course+Shopping';
+var data_tooltip = 'More info about access during shopping period';
+var tooltip_link = '<a data-tooltip title="' + data_tooltip + '" target="_blank" href="' +
+  shopping_help_doc_url + '"><i class="icon-question"></i></a>';
+
+var no_user_canvas_login = '<div class="tltmsg tltmsg-shop"><p class="participate-text">Students: ' +
+  '<a href="'+login_url+'">login</a> to get more access during shopping period.' + tooltip_link + '</p></div>';
+
+var is_course = (course_id > 0);
+var user_enrolled = false;
+var is_shopper = false;
+var is_teacher = false;
+var is_student = false;
+
+/**
+ * Create the div that will hold the shoping banner
+ * @type {html element}
+ */
+var shopping_banner = jQuery('<div/>', {
+  id: 'course-shopping',
+  class: 'tltmsg'
+});
+
+/**
+ * Are we on an admin page
+ * @type {boolean}
+ */
+var on_admin_page = ((window.location.pathname).indexOf('settings') != -1);
+
+/**
+ * Are we on the speed grader page
+ * @type {boolean}
+ */
+var on_speed_grader_page = ((window.location.pathname).indexOf('speed_grader') != -1);
+
+/**
+ * Are we on the submissions page
+ * @type {boolean}
+ */
+var on_submissions_page = ((window.location.pathname).indexOf('submissions') != -1);
+
+/**
+ * Are we on any of the special pages described above
+ * @type {boolean}
+ */
+var on_special_page = on_admin_page || on_speed_grader_page || on_submissions_page;
+
 /**
  * check to see if the '#unauthorized_message' is being rendered  and only proceed
  * with additional checks to show shopping messages if authorized

--- a/js/shop.js
+++ b/js/shop.js
@@ -44,7 +44,7 @@ if (unauthorized_message_not_shown){
             var num_enrollments = course_enrollments.length;
             for (var n = 0; n < num_enrollments; n++) {
               var erole = course_enrollments[n]['role'];
-              var type =  course_enrollments['type'];
+              var type =  course_enrollments[n]['type'];
               user_enrolled = true;
               is_shopper = (erole == 'Shopper');
               is_student = (erole == 'StudentEnrollment') || (erole == 'Guest');

--- a/js/shop.js
+++ b/js/shop.js
@@ -7,7 +7,7 @@
  */
 var allowed_terms = ['3', '4', '179', '595', '596', '603', '487', '569', '1','8','447','591','597', '342'];
 
-if (is_unauthorized_message_shown){
+if (unauthorized_message_not_shown){
   var un = $('ul#identity > li.user_name > a').text();
   if ( !un ) {
     $.getJSON(course_url, function( data ) {
@@ -28,7 +28,7 @@ if (is_unauthorized_message_shown){
     var sis_user_id = '';
     $.getJSON(user_url, function( data ) {
       sis_user_id = get_sis_user_id(data);
-      if (course_id > 0) {
+      if (course_id_is_valid) {
         $.getJSON(course_url, function( data ) {
 
           var course_is_available = is_course_available(data['workflow_state']);

--- a/js/shop.js
+++ b/js/shop.js
@@ -19,7 +19,7 @@ if (is_unauthorized_message_shown){
         /*
          TLT-668 - only allow shopping for terms that are in the whitelist.
          */
-        if (is_term_allowed(data['enrollment_term_id'])) {
+        if (is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
           shopping_banner.append(no_user_canvas_login);
           $('#breadcrumbs').after(shopping_banner);
         }
@@ -40,7 +40,7 @@ if (is_unauthorized_message_shown){
             /*
              TLT-668 - only allow shopping for terms that are in the whitelist.
              */
-            if (is_term_allowed(data['enrollment_term_id'])) {
+            if (is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
               var c_id = data['id'];
               if (course_id == c_id) {
                 var num_enrollments = data['enrollments'].length;
@@ -107,7 +107,7 @@ if (is_unauthorized_message_shown){
                 $('#breadcrumbs').after(shopping_banner);
               }
             }
-          } else if (on_admin_page && is_term_allowed(data['enrollment_term_id'])) {
+          } else if (on_admin_page && is_term_allowed(data['enrollment_term_id'], allowed_terms)) {
             // on course admin page for course in a whitelisted term --> disable is_public_to_auth_users
             var $iptau_checkbox = $('#course_is_public_to_auth_users');
             $iptau_checkbox.closest("div").addClass("selection-disabled");


### PR DESCRIPTION
This PR does a couple of things, the story called for adding a new banner for student and guest roles.
This part was easy, we get the user roles from canvas so we can determine which banner to display.

I took this opportunity to do a little refactoring of the code. I had a conversation with Colin about the javscript process and determined that we could pull out some of the common shopping code and put it into a new global file. This file which is in the canvas-branding-global repo now contains the banner text and other code that will be used by all the shopping js files in each school. This will make it easier to change text in the future because you'll only need to do it in one place. This is a first step, I think there's more we can do to simplify this code. There is another PR in the canvas-branding-global repo for the new global file. Also, once the code is approved, it will need to get updated in each of the school shop.js files. This can be a simple update once we are happy with the code. 
