### PR TITLE
tlt-2664: course selection styling updates 

### DIFF
--- a/css/shop.css
+++ b/css/shop.css
@@ -20,8 +20,6 @@
     text-align: left;
 }
 
-#course-shopping p.participate-text{ font-size: 16px; }
-
 .tltmsg{
     display: inline-block;
     width: 92%;
@@ -29,16 +27,6 @@
     border: solid 1px #ecebeb;
     margin: 0.5em 2%;
     padding: 0.5em 2%;
-}
-
-.tltmsg-shop{
-    background: #f2f2f2;
-    border: solid 1px #d0d0d0;
-    font-size: 16px;
-}
-
-.tltmsg-shop em{
-    font-size: 12px;
 }
 
 .selection-disabled{

--- a/js/shop.js
+++ b/js/shop.js
@@ -100,10 +100,10 @@ var huCourseSelection = (function (){
   var tooltip_link = '<a data-tooltip title="' + data_tooltip + '" target="_blank" href="' +
     course_selection_help_doc_url + '"><i class="icon-question"></i></a>';
 
-  var no_user_canvas_login = '<div class="tltmsg tltmsg-shop">' +
-    '<p class="participate-text">Students: <a href="'+login_url+'">login</a> ' +
+  var no_user_canvas_login = '<div class="tltmsg">' +
+    '<h1>Students: <a href="'+login_url+'">login</a> ' +
     'to get more access during course selection <span class="text-nowrap">' +
-    'period. ' + tooltip_link + '</span></p></div>';
+    'period. ' + tooltip_link + '</span></h1></div>';
 
   /**
    * Return the user id from the api data

--- a/js/shop.js
+++ b/js/shop.js
@@ -100,9 +100,8 @@ var huCourseSelection = (function (){
   var tooltip_link = '<a data-tooltip title="' + data_tooltip + '" target="_blank" href="' +
     course_selection_help_doc_url + '"><i class="icon-question"></i></a>';
 
-  var no_user_canvas_login = '<div class="tltmsg">' +
-    '<h1>Students: <a href="'+login_url+'">login</a> ' +
-    'to get more access during course selection <span class="text-nowrap">' +
+  var no_user_canvas_login = '<h1>Students: <a href="'+login_url+'">login</a>' +
+    ' to get more access during course selection <span class="text-nowrap">' +
     'period. ' + tooltip_link + '</span></h1></div>';
 
   /**


### PR DESCRIPTION
Unauthenticated user message styling updates per Vittorio's comments on [text styles](https://tlt.slack.com/files/vittorio/F211A42RL/pasted_image_at_2016_08_12_16_34.png) and [banner styles](https://tlt.slack.com/archives/scrumteam/p1471034998000778):

> - the plain text style of the screen for the “Unauthenticated user banner” (Test Details #1) should match the text header style of Test Details #6.
> - the current “Unauthenticated user banner” shall not be on a grayish background.

Updated look, from https://canvas.dev.tlt.harvard.edu/courses/3828: 
![screen shot 2016-08-15 at 11 28 25 am](https://cloud.githubusercontent.com/assets/8975317/17669368/6b3607e0-62db-11e6-80b5-1aca20a8612b.png)
