### PR TITLE
Switch policy wizard id

### DIFF
--- a/js/checklist.js
+++ b/js/checklist.js
@@ -1,6 +1,6 @@
 (function() {
 	// Hard-coded external tool IDs for account_id=39 (i.e. Harvard College/GSAS)
-	var POLICY_WIZARD_TOOL_ID = 1509;
+	var POLICY_WIZARD_TOOL_ID = 33928;
 	var MANAGE_COURSE_TOOL_ID = 17079;
 		
 	// Ensure that these scripts only run on the appropriate pages


### PR DESCRIPTION
Change the policy wizard id given that we uninstalled the previous version of the wizard on canvas and installed a new one.