### PR TITLE
Hide Conferences in course navigation

### DIFF
--- a/css/coursenav.css
+++ b/css/coursenav.css
@@ -1,0 +1,6 @@
+/* 
+Per request from FAS Service Team 3/13/20, hiding Web Conferences in course navigation. 
+*/
+#left-side nav .section > a.conferences {
+    display: none;
+}


### PR DESCRIPTION
Hide Conferences in course navigation per FAS Service Team request 3/13/20.

@dodget 