### PR TITLE
Hide Conferences from mobile menu

### DIFF
--- a/css/coursenav.css
+++ b/css/coursenav.css
@@ -1,6 +1,12 @@
 /* 
-Per request from FAS Service Team 3/13/20, hiding Web Conferences in course navigation. 
+Per request from FAS Service Team 3/13/20, hiding Web Conferences from the course navigation.
 */
 #left-side nav .section > a.conferences {
+    display: none;
+}
+/*
+Note: In order to hide the mobile nav item, custom JS is used to add the expected class to the DOM.
+*/
+#mobileContextNavContainer .conferences-mobile-item {
     display: none;
 }

--- a/js/coursenav.js
+++ b/js/coursenav.js
@@ -1,0 +1,58 @@
+// Per request from FAS Service Team 3/13/20, "Conferences" should be hidden from the navigation.
+//
+// The Web Conferences item appears in two places:
+//  - left-side navigation 
+//  - mobile context menu
+//
+// The mobile context menu is populated dynamically, so it can't be hidden on page load.
+// The JS below ensures that the appropriate DOM element has a class attached to it
+// so that CSS can hide it.
+//
+// See also: coursenav.css
+(function () {
+    "use strict";
+
+    function get_course_id() {
+        var matched = window.location.pathname.match(/^\/courses\/(\d+)/);
+        if (!matched) {
+            return false;
+        }
+        return matched[1];
+    }
+
+    function hide_mobile_nav_item(url) {
+        var selector = '#mobileContextNavContainer a[href="' + url + '"]';
+        var el = document.querySelector(selector);
+        if (!el) {
+            return;
+        }
+        el.parentNode.parentNode.classList.add("conferences-mobile-item");
+    }
+
+    function watch_mobile_nav_for_changes(callback) {
+        var el = document.querySelector("#mobileContextNavContainer");
+        if (!el) {
+            return;
+        }
+
+        var observer;
+        if (window.MutationObserver) {
+            observer = new MutationObserver(callback);
+            observer.observe(el, {
+                attributes: false,
+                childList: true,
+                subtree: true
+            })
+        }
+    }
+
+    var COURSE_ID = get_course_id();
+    var CONFERENCES_URL = '/courses/' + COURSE_ID + '/conferences';
+
+    if (COURSE_ID) {
+        watch_mobile_nav_for_changes(function (mutationsList, observer) {
+            hide_mobile_nav_item(CONFERENCES_URL);
+        });
+    }
+
+})();


### PR DESCRIPTION
Update to ensure that _Conferences_ is hidden from both the mobile context menu as well as the left-side navigation.

The left-side navigation item is easily hidden with pure CSS (see #34), but the mobile context menu is more challenging because it populates the DOM when the menu is activated and contains markup like this:

```
<span class="fxIji_bGBk fxIji_bWOh fxIji_NmrE fxIji_cKZZ fxIji_yZGt fxIji_dTOw">
    <span class="bNerA_bGBk bNerA_dTOw bNerA_NmrE bNerA_qfdC bNerA_yZGt ">
        ...
    </span>
</span>
```

The JS simply enables the CSS to hide the menu item in the same way it does in the left side navigation. If at any point in the future, reasonable class names are used when rendering the mobile menu, we can dispense with the JS.
