### PR TITLE
Update Import Content Notification

### DIFF
--- a/js/checklist.js
+++ b/js/checklist.js
@@ -9,58 +9,6 @@
 		if(window.ENV.COURSE_WIZARD) {
 			require(['jquery', 'jsx/course_wizard/ListItems'], modify_setup_checklist);
 		}
-		if (/^\/courses\/\d+\/content_migrations/.test(window.location.pathname)) {
-			require(['jquery'], modify_import_content_page);
-		}
-	}
-
-
-	/**
-	 * This function adds some text about migrating content from iSites to the "Import Content" page.
-	 *
-	 * Due to the fact that the "Import Content" form is dynamically generated at page render time,
-	 * there is some extra complexity in the code to poll for the existence of the DOM element
-	 * before trying to add the text. Otherwise, this could be simplified to a single jquery call.
-	 */
-	 function modify_import_content_page($) {
-		
-		// Holds the content that will be added to the page
-		var BASE_COURSE_URL = window.location.pathname.replace("/content_migrations", "");
-		var url = BASE_COURSE_URL + "/external_tools/" + MANAGE_COURSE_TOOL_ID;
-		var html = '<p>If you would like to incorporate content from a previous iSite, click <a href="'+url+'" title="Import iSites Content">here</a>.</p>';
-
-		// Holds a function that when executed, will call its callback when the selector returns an element.
-		// The assumption is that the element may not exist in the DOM on the first try.
-		var poll_for_element = pollForElement("#migrationConverterContainer > h1", 20, 100, function($el) {
-			$el.after(html);
-		});
-
-		poll_for_element();
-
-		/**
-		 * Poll the DOM for the existence of an element and then execute
-		 * the "success" callback when/if the element is found to exist.
-		 *
-		 * @param {(string|jQuery)} el the element to find
-		 * @param {integer} num_tries the number of times to test for existence
-		 * @param {integer} timeout the interval between tries
-		 * @param {function} success the callback to execute when/if the el is found
-		 * @returns {function} a function that will initiate the polling process
-		 */
-		function pollForElement(el, num_tries, timeout, success) {
-			var callback = function() {
-				var exists = $(el).length !== 0;
-				--num_tries;
-				if (exists) {
-					success($(el));
-				} else {
-					if (num_tries > 0) {
-						window.setTimeout(callback, timeout);
-					}
-				}
-			};
-			return callback;
-		}
 	}
 	
 	/**

--- a/js/course_settings_import.js
+++ b/js/course_settings_import.js
@@ -12,13 +12,14 @@
     function show_import_notification() {
         var content = document.querySelector("#content");
         var notification = document.createElement("div");
-        notification.className = "ic-notification";
+        notification.className = "ic-notification ic-notification--alert";
         notification.innerHTML =
             '<div class="ic-notification__icon" role="presentation">' +
                 '<i class="icon-info"></i>' +
-                '<span class="screenreader-only">information</span>' +
+                '<span class="screenreader-only">alert</span>' +
             '</div>' +
             '<div style="width:100%;padding:.5em;">' +
+                '<b>Attention Spring 2020 Courses:&nbsp;</b>' +
                 'Use "Select specific content" to exclude Calendar Events when copying from previous courses. Events will include old Zoom links that will not work in your new course. <a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=8b1898dcdba0a810babda8dad39619bd" target="_blank">Learn how to exclude these items</a> when importing your course content.' +
             '</div>';
         content.insertBefore(notification, content.firstChild);

--- a/js/course_settings_import.js
+++ b/js/course_settings_import.js
@@ -27,8 +27,13 @@
 
     function update_selective_import_value() {
         var radio = document.querySelector("#migrationConverterContainer input[type=radio][name=selective_import][value=true]");
-        if(radio) {
+        if(!radio) {
+            return;
+        }
+        if(!radio.dataset.initialized) {
+            radio.dataset.initialized = "yes";
             radio.checked = true;
+            radio.click(); // simulating a click because the form validator doesn't recognize it as checked
         }
     }
 

--- a/js/course_settings_import.js
+++ b/js/course_settings_import.js
@@ -1,0 +1,56 @@
+// Per request from FAS Service Team 11/12/20, "Import Content" should be
+// modified as follows:
+// 
+// 1. Adds a notification advising faculty to exclude Calendar Events when 
+//    copying a course, since events will include old Zoom URLs that don't work.
+// 2. Automatically sets the default option to "Select specific content" instead 
+//    of "All content" when copying a canvas course.
+//
+(function() {
+    "use strict";
+
+    function show_import_notification() {
+        var content = document.querySelector("#content");
+        var notification = document.createElement("div");
+        notification.className = "ic-notification";
+        notification.innerHTML =
+            '<div class="ic-notification__icon" role="presentation">' +
+                '<i class="icon-info"></i>' +
+                '<span class="screenreader-only">information</span>' +
+            '</div>' +
+            '<div style="width:100%;padding:.5em;">' +
+                'Use "Select specific content" to exclude Calendar Events when copying from previous courses. Events will include old Zoom links that will not work in your new course. <a href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=8b1898dcdba0a810babda8dad39619bd" target="_blank">Learn how to exclude these items</a> when importing your course content.' +
+            '</div>';
+        content.insertBefore(notification, content.firstChild);
+    }
+
+    function update_selective_import_value() {
+        var radio = document.querySelector("#migrationConverterContainer input[type=radio][name=selective_import][value=true]");
+        if(radio) {
+            radio.checked = true;
+        }
+    }
+
+    function watch_for_changes(el, callback) {
+        if(!el) {
+            return;
+        }
+        if (window.MutationObserver) {
+            var observer = new MutationObserver(callback);
+            observer.observe(el, {
+                attributes: false,
+                childList: true,
+                subtree: true
+            })
+        }
+        return observer;
+    }
+
+    if (/^\/courses\/\d+\/content_migrations/.test(window.location.pathname)) {
+        show_import_notification();
+        watch_for_changes(document.querySelector("#migrationConverterContainer"), function(mutationsList, observer) {
+            update_selective_import_value();
+        });
+    }
+
+})();


### PR DESCRIPTION
This PR updates the "Import Content" page.

**Changes:**

- Removed the old message about incorporating iSites content (not relevant anymore).
- Added advisory about excluding Calendar Events due to Zoom URLs.
- Updated content option so that "Select specific content" is automatically selected when copying a canvas course

**Screenshot:**

![course-import-settings-update](https://user-images.githubusercontent.com/1165361/99276417-a5afc800-27fa-11eb-81a3-303c9562d2e8.png)
